### PR TITLE
fix lucky mode calling complete callback multiple times

### DIFF
--- a/lib/finder.js
+++ b/lib/finder.js
@@ -159,6 +159,9 @@ Finder.prototype.unplan = function(path) {
   if (path) this.found.apply(this, arguments)
 
   var end = function() {
+    if (this.planned == null)
+      return
+
     if (--this.planned<=0 || (this.numFound && this.lucky)) {
       this.planned = null
       


### PR DESCRIPTION
As reported in #10, when in "lucky" mode, multiple "found" callbacks could still be called instead of the first one only

This fixes the issue from suite about Opera's array being 5 elements. When you make `planned = null` in L163 and the callback fires once again, `--this.planned` evaluates to `-1` and `oncomplete` is fired once again, and again over and over
