### PR TITLE
fix #13 use tmpdir as cwd for spawned children

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,7 @@ module.exports = function (names, opts, complete) {
   var found = []
 
   var end = after(names.length, function(){
-    // WMIC creates a temporary file for some reason
-    var tmpfile = path.join(__dirname, 'TempWmicBatchFile.bat')
-    return fs.unlink(tmpfile, function(){
-      complete(found)
-    })
+    complete(found)
   })
 
   names.forEach(function(name){

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,4 +1,5 @@
 var spawn = require('child_process').spawn
+var tmpdir = require('os').tmpdir()
 
 // Asserts the command had output (after trimming) 
 // and exit code was 0. Arguments are not escaped,
@@ -21,7 +22,9 @@ module.exports = function (cmd, args, verbatim, cb) {
 
   var child = spawn(cmd, args, {
     // Forgot why or where this was necessary
-    cwd: undefined, env: undefined,
+    env: undefined,
+    // WMIC creates a temporary file for some reason
+    cwd: tmpdir,
     windowsVerbatimArguments: verbatim,
     stdio: [ 'ignore', 'pipe', 'ignore' ]
   })


### PR DESCRIPTION
When cwd is not explicitly set, and the module is required
from a third-party code, then spawned children used the cwd
of the requester module:

Say I created a code like this (myfile.js):

```
var launcher = require('browser-launcher2');

launcher.detect(function(available) {
    console.log('Available browsers:');
    console.dir(available);
});
```

With undefined cwd, this creates `TempWmicBatchFile.bat` next to
`myfile.js` instead of next to the module's files.

Let's instead use OS-provided tmpdir and don't care about deleting
the temp files on our side.
