### PR TITLE
Detect the new chromium-based MS Edge

### DIFF
--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -106,6 +106,16 @@ exports.ie = {
   }
 }
 
+exports.msedge = {
+  bin: 'msedge.exe',
+
+  find: function () {
+    this.programFiles('Microsoft\\Edge Beta\\Application')
+    this.programFiles('Microsoft\\Edge\\Application')
+    this.startMenu()
+  }
+}
+
 exports.maxthon = {
   bin: 'Maxthon.exe',
 


### PR DESCRIPTION
As noted in #21, until now Edge has been a funky beast built into the OS itself.

Now though, it's been rebuilt on Chrome, and it's effectively just another Chromium wrapper. You can detect and launch it standalone, just like anything else. It's currently still Beta, but very usable, and planned for official release in January.

This PR adds proper support for it. I've set up a Windows 10 VM and installed a whole bunch of things, and with this PR in place `node cli.js --debug` prints:

```
$ node cli.js --debug
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Google\Update /v LastInstallerSuccessLaunchCmdLine +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ HKCU\Software\Google\Update /v LastInstallerSuccessLaunchCmdLine +2ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe +1ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe +1ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ HKCU\Software\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Clients\StartMenuInternet\Google Chrome\shell\open\command +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Clients\StartMenuInternet\Google Chrome\shell\open\command +1ms
  win-detect-browsers Found chrome (stable) (64):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ Software\Wow6432Node\Google\Update\ClientState\{8A69D345-D564-463C-AFF1-A69D9E530F96}\LastInstallerSuccessLaunchCmdLine +0ms
  win-detect-browsers Found chrome (canary) (64):
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ Software\Google\Update\ClientState\{4EA16AC7-FD5A-47C3-875B-DBF4A2008C20}\LastInstallerSuccessLaunchCmdLine +0ms
  win-detect-browsers firefox: found key "70.0.1 (x86 en-US)" in HKLM\Software\Wow6432Node\Mozilla\Mozilla Firefox /v CurrentVersion +1ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files\Internet Explorer\iexplore.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Clients\StartMenuInternet\iexplore.exe\shell\open\command +0ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files\Internet Explorer\iexplore.exe
  win-detect-browsers   @ HKLM\Software\Clients\StartMenuInternet\iexplore.exe\shell\open\command +1ms
  win-detect-browsers Found chrome (canary):
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ Software\Classes\ChromeSSHTM.BC355NTUYZBE365DOMSF45YR2M\shell\open\command +1ms
  win-detect-browsers Found chrome (stable):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ Software\Classes\ChromeHTML\shell\open\command +0ms
  win-detect-browsers Found firefox:
  win-detect-browsers   - C:\Program Files (x86)\Mozilla Firefox\firefox.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Mozilla\Mozilla Firefox\70.0.1 (x86 en-US)\Main /v PathToExe +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ default location +1ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ default location +2ms
  win-detect-browsers Found firefox:
  win-detect-browsers   - C:\Program Files (x86)\Mozilla Firefox\firefox.exe
  win-detect-browsers   @ default location +1ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files (x86)\Internet Explorer\iexplore.exe
  win-detect-browsers   @ default location +1ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files\Internet Explorer\iexplore.exe
  win-detect-browsers   @ default location +1ms
  win-detect-browsers Found msedge:
  win-detect-browsers   - C:\Program Files (x86)\Microsoft\Edge Beta\Application\msedge.exe
  win-detect-browsers   @ default location +2ms
MSEDGE 79 64-bit
├── Path:    C:\Program Files (x86)\Microsoft\Edge Beta\Application\msedge.exe
├── Version: 79.0.309.18
└─┬ Info
  ├── FileVersion:      79.0.309.18
  ├── CompanyName:      Microsoft Corporation
  ├── FileDescription:  Microsoft Edge
  ├── InternalName:     msedge_exe
  ├── LegalCopyright:   Copyright Microsoft Corporation. All rights reserved.
  ├── OriginalFilename: msedge.exe
  ├── ProductName:      Microsoft Edge
  ├── ProductVersion:   79.0.309.18
  ├── CompanyShortName: Microsoft
  ├── ProductShortName: Edge
  ├── LastChange:       829ed31878a019567b2956b91bb541d17127f21d
  └── Official Build:   1

IE 11 64-bit
├── Path:    C:\Program Files\Internet Explorer\iexplore.exe
├── Version: 11.00.18362.1
└─┬ Info
  ├── FileVersion:      11.00.18362.1
  ├── CompanyName:      Microsoft Corporation
  ├── FileDescription:  Internet Explorer
  ├── InternalName:     iexplore
  ├── LegalCopyright:   © Microsoft Corporation. All rights reserved.
  ├── OriginalFilename: IEXPLORE.EXE
  ├── ProductName:      Internet Explorer
  └── ProductVersion:   11.00.18362.1

IE 11 32-bit
├── Path:    C:\Program Files (x86)\Internet Explorer\iexplore.exe
├── Version: 11.00.18362.1
└─┬ Info
  ├── FileVersion:      11.00.18362.1
  ├── CompanyName:      Microsoft Corporation
  ├── FileDescription:  Internet Explorer
  ├── InternalName:     iexplore
  ├── LegalCopyright:   © Microsoft Corporation. All rights reserved.
  ├── OriginalFilename: IEXPLORE.EXE
  ├── ProductName:      Internet Explorer
  └── ProductVersion:   11.00.18362.1

CHROME 80 64-bit
├── Path:    C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
├── Version: 80.0.3964.0
└─┬ Info
  ├── FileVersion:      80.0.3964.0
  ├── CompanyName:      Google LLC
  ├── FileDescription:  Google Chrome
  ├── InternalName:     chrome_exe
  ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
  ├── OriginalFilename: chrome.exe
  ├── ProductName:      Google Chrome
  ├── ProductVersion:   80.0.3964.0
  ├── CompanyShortName: Google
  ├── ProductShortName: Chrome
  ├── LastChange:       75f9d4c9f31c6fa9302434e99ced85dc5d8e2069-refs/branch-heads/3964@{#1}
  └── Official Build:   1

CHROME 80 CANARY 64-bit
├── Path:    C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
├── Version: 80.0.3968.0
├── GUID:    4EA16AC7-FD5A-47C3-875B-DBF4A2008C20
├─┬ Info
│ ├── FileVersion:      80.0.3968.0
│ ├── CompanyName:      Google LLC
│ ├── FileDescription:  Google Chrome
│ ├── InternalName:     chrome_exe
│ ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
│ ├── OriginalFilename: chrome.exe
│ ├── ProductName:      Google Chrome
│ ├── ProductVersion:   80.0.3968.0
│ ├── CompanyShortName: Google
│ ├── ProductShortName: Chrome
│ ├── LastChange:       942a57022a321872a10830a40120904d79bd0536-refs/branch-heads/3968@{#1}
│ └── Official Build:   1
└─┬ Uninstall
  ├── path: C:\Users\User\AppData\Local\Google\Chrome SxS\Application\80.0.3968.0\Installer\setup.exe
  └─┬ arguments
    ├── --uninstall
    └── --chrome-sxs

CHROME 78 STABLE 64-bit
├── Path:    C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
├── Version: 78.0.3904.97
├── GUID:    8A69D345-D564-463C-AFF1-A69D9E530F96
├─┬ Info
│ ├── FileVersion:      78.0.3904.97
│ ├── CompanyName:      Google LLC
│ ├── FileDescription:  Google Chrome
│ ├── InternalName:     chrome_exe
│ ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
│ ├── OriginalFilename: chrome.exe
│ ├── ProductName:      Google Chrome
│ ├── ProductVersion:   78.0.3904.97
│ ├── CompanyShortName: Google
│ ├── ProductShortName: Chrome
│ ├── LastChange:       021b9028c246d820be17a10e5b393ee90f41375e-refs/branch-heads/3904@{#859}
│ └── Official Build:   1
└─┬ Uninstall
  ├── path: C:\Program Files (x86)\Google\Chrome\Application\78.0.3904.97\Installer\setup.exe
  └─┬ arguments
    ├── --uninstall
    ├── --system-level
    └── --verbose-logging

FIREFOX 70 RELEASE 32-bit
├── Path:    C:\Program Files (x86)\Mozilla Firefox\firefox.exe
├── Version: 70.0.1
└─┬ Info
  ├── FileVersion:      70.0.1
  ├── LegalCopyright:   ©Firefox and Mozilla Developers; available under the MPL 2 license.
  ├── CompanyName:      Mozilla Corporation
  ├── FileDescription:  Firefox
  ├── ProductVersion:   70.0.1
  ├── InternalName:     Firefox
  ├── LegalTrademarks:  Firefox is a Trademark of The Mozilla Foundation.
  ├── OriginalFilename: firefox.exe
  ├── ProductName:      Firefox
  └── BuildID:          20191030021342

Found 7 browsers in 20 ways within 160ms.
```

You can see Edge at the top of the detected list there.

The 'Edge Beta' folder is the current directory. I'm assuming in future that 'Edge' will be the official folder, but just on common sense, I don't have any hard evidence for that.