### PR TITLE
Improve detection of Chrome channel variants

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,9 +59,9 @@ detect(argv._, argv, function (err, browsers, methods) {
         labels.push(b.channel.toUpperCase())
       }
 
-      if (b.arch === 'amd64' || b.bitness === 64) {
+      if (b.arch === 'amd64') {
         labels.push('64-bit')
-      } else if (b.arch === 'i386' || b.bitness === 32) {
+      } else if (b.arch === 'i386') {
         labels.push('32-bit')
       }
 
@@ -108,7 +108,7 @@ function ordered (a) {
   const remaining = new Set(Object.keys(a))
   const objects = []
 
-  for (const k of ['name', 'path', 'version', 'channel', 'arch', 'bitness']) {
+  for (const k of ['name', 'path', 'version', 'channel', 'arch']) {
     if (k in a) {
       b[k] = a[k]
       remaining.delete(k)

--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -6,13 +6,17 @@ exports.chrome = {
   find: function () {
     // Joined with filename (or [browser name].exe)
     this.dir('LOCALAPPDATA', 'Google\\Chrome\\Application')
-
+    this.dir('LOCALAPPDATA', 'Google\\Chrome Beta\\Application')
+    this.dir('LOCALAPPDATA', 'Google\\Chrome Dev\\Application')
     // Chrome Canary
     this.dir('LOCALAPPDATA', 'Google\\Chrome SxS\\Application')
 
     // programFiles() is a shortcut to dir() that checks both
     // "Program Files" and "Program Files (x86)" if on 64-bit Windows
     this.programFiles('Google\\Chrome\\Application')
+    this.programFiles('Google\\Chrome Beta\\Application')
+    this.programFiles('Google\\Chrome Dev\\Application')
+    this.programFiles('Google\\Chrome SxS\\Application')
 
     // Expanded to HKEY_LOCAL_MACHINE\Software, HKEY_CURRENT_USER\Software
     // and if on a x64 machine, their 32-bit (Software\WoW6432) counterparts.

--- a/lib/chrome/find-progids.js
+++ b/lib/chrome/find-progids.js
@@ -29,11 +29,7 @@ function queryHive (self, hive, done) {
         if (err) return next(err.notFound ? null : err)
 
         const metadata = {
-          channel: id.startsWith('ChromeSSHTM.') ? 'canary' : {
-            'ChromeHTML': null, // In some cases this can be ambiguous
-            'ChromeBHTML': 'beta',
-            'ChromeDHTML': 'dev'
-          }[id]
+          channel: getChromeChannel(id)
         }
 
         self.found(extractPath(bin), metadata, key, next)
@@ -47,4 +43,11 @@ function isChromeHTML (id) {
     id === 'ChromeBHTML' ||
     id === 'ChromeDHTML' ||
     id.slice(0, 12) === 'ChromeSSHTM.'
+}
+
+function getChromeChannel (id) {
+  if (id.startsWith('ChromeSSHTM.')) return 'canary'
+  if (id === 'ChromeBHTML') return 'beta'
+  if (id === 'ChromeDHTML') return 'dev'
+  return null // Unknown or ChromeHTML (which can be ambiguous)
 }

--- a/lib/chrome/find-progids.js
+++ b/lib/chrome/find-progids.js
@@ -29,7 +29,11 @@ function queryHive (self, hive, done) {
         if (err) return next(err.notFound ? null : err)
 
         const metadata = {
-          channel: id === 'ChromeHTML' ? 'stable' : 'canary'
+          channel: id.startsWith('ChromeSSHTM.') ? 'canary' : {
+            'ChromeHTML': null, // In some cases this can be ambiguous
+            'ChromeBHTML': 'beta',
+            'ChromeDHTML': 'dev'
+          }[id]
         }
 
         self.found(extractPath(bin), metadata, key, next)
@@ -39,5 +43,8 @@ function queryHive (self, hive, done) {
 }
 
 function isChromeHTML (id) {
-  return id === 'ChromeHTML' || id.slice(0, 12) === 'ChromeSSHTM.'
+  return id === 'ChromeHTML' ||
+    id === 'ChromeBHTML' ||
+    id === 'ChromeDHTML' ||
+    id.slice(0, 12) === 'ChromeSSHTM.'
 }

--- a/lib/chrome/find-update-clients.js
+++ b/lib/chrome/find-update-clients.js
@@ -7,12 +7,15 @@ const { basename, resolve, dirname } = require('path')
 const registry = require('../registry')
 
 const GUIDS = [
+  '401C381F-E0DE-4B85-8BD8-3F3F14FBDA57', // dev
+  '8237E44A-0054-442C-B6B6-EA0509993955', // beta
   '8A69D345-D564-463C-AFF1-A69D9E530F96', // 32
   '4DC8B4CA-1BDA-483E-B5FA-D3C12E15B62D', // 64
   '4EA16AC7-FD5A-47C3-875B-DBF4A2008C20' // canary
 ]
 
 const CHANNELS = [
+  'stable',
   'canary',
   'beta',
   'dev'
@@ -91,5 +94,5 @@ function getReleaseChannel (ap) {
     if (ap.has(channel)) return channel
   }
 
-  return 'stable'
+  return null
 }

--- a/lib/chrome/find-update-clients.js
+++ b/lib/chrome/find-update-clients.js
@@ -48,7 +48,6 @@ function queryState (self, hive, guid, inWoW, done) {
 
       const metadata = {
         channel: getReleaseChannel(ap),
-        bitness: ap.has('x64') ? 64 : 32,
         guid
       }
 

--- a/lib/finder.js
+++ b/lib/finder.js
@@ -194,7 +194,6 @@ Finder.prototype.found = function (bin, metadata, method, cb, _skipPre) {
 
     if (metadata) {
       if (metadata.channel) debugName.push(`(${metadata.channel})`)
-      if (metadata.bitness) debugName.push(`(${metadata.bitness})`)
     }
 
     debug('Found %s:\n  - %s\n  @ %s', debugName.join(' '), bin, method)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "win-version-info": "~3.0.0",
     "windows-env": "~1.0.1",
     "xtend": "^4.0.0",
-    "yargs": "~13.3.0"
+    "yargs": "~14.0.0"
   },
   "devDependencies": {
     "hallmark": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,6 @@ Additional properties are usually available but not guaranteed:
 - `uninstall` (object): Chrome only. Uninstaller info with:
   - `path` (string): path to installer;
   - `arguments` (array): arguments to installer in order to uninstall.
-- `bitness` (number): Chrome only. 64 or 32.
 - `guid` (string): Chrome only.
 
 ## CLI
@@ -234,7 +233,6 @@ On Windows 10 with `--json`:
     "version": "68.0.3436.0",
     "channel": "canary",
     "arch": "amd64",
-    "bitness": 64,
     "guid": "4EA16AC7-FD5A-47C3-875B-DBF4A2008C20",
     "info": {
       "FileVersion": "68.0.3436.0",
@@ -264,7 +262,6 @@ On Windows 10 with `--json`:
     "version": "66.0.3359.181",
     "channel": "stable",
     "arch": "amd64",
-    "bitness": 64,
     "guid": "8A69D345-D564-463C-AFF1-A69D9E530F96",
     "info": {
       "FileVersion": "66.0.3359.181",


### PR DESCRIPTION
Working towards a fix for #55, based on the comments there. This implements the suggested change, and improves the detection in general, especially for beta & dev channels.

Output of `node cli.js --debug` with lots of Chromes installed on a Windows 10 VM:

```
$ node cli.js --debug
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Google\Update /v LastInstallerSuccessLaunchCmdLine +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ HKCU\Software\Google\Update /v LastInstallerSuccessLaunchCmdLine +4ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe +2ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ HKCU\Software\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe +1ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Clients\StartMenuInternet\Google Chrome\shell\open\command +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ HKLM\Software\Clients\StartMenuInternet\Google Chrome\shell\open\command +0ms
  win-detect-browsers Found chrome (32):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
  win-detect-browsers   @ Software\Wow6432Node\Google\Update\ClientState\{401C381F-E0DE-4B85-8BD8-3F3F14FBDA57}\LastInstallerSuccessLaunchCmdLine +1ms
  win-detect-browsers Found chrome (32):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
  win-detect-browsers   @ Software\Wow6432Node\Google\Update\ClientState\{8237E44A-0054-442C-B6B6-EA0509993955}\LastInstallerSuccessLaunchCmdLine +1ms
  win-detect-browsers Found chrome (stable) (64):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ Software\Wow6432Node\Google\Update\ClientState\{8A69D345-D564-463C-AFF1-A69D9E530F96}\LastInstallerSuccessLaunchCmdLine +0ms
  win-detect-browsers Found chrome (canary) (64):
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ Software\Google\Update\ClientState\{4EA16AC7-FD5A-47C3-875B-DBF4A2008C20}\LastInstallerSuccessLaunchCmdLine +0ms
  win-detect-browsers firefox: found key "70.0.1 (x86 en-US)" in HKLM\Software\Wow6432Node\Mozilla\Mozilla Firefox /v CurrentVersion +1ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files\Internet Explorer\iexplore.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Clients\StartMenuInternet\iexplore.exe\shell\open\command +0ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files\Internet Explorer\iexplore.exe
  win-detect-browsers   @ HKLM\Software\Clients\StartMenuInternet\iexplore.exe\shell\open\command +1ms
  win-detect-browsers Found chrome (canary):
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ Software\Classes\ChromeSSHTM.BC355NTUYZBE365DOMSF45YR2M\shell\open\command +1ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ Software\Classes\ChromeHTML\shell\open\command +0ms
  win-detect-browsers Found chrome (dev):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
  win-detect-browsers   @ Software\Classes\ChromeDHTML\shell\open\command +0ms
  win-detect-browsers Found chrome (beta):
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
  win-detect-browsers   @ Software\Classes\ChromeBHTML\shell\open\command +0ms
  win-detect-browsers Found firefox:
  win-detect-browsers   - C:\Program Files (x86)\Mozilla Firefox\firefox.exe
  win-detect-browsers   @ HKLM\Software\Wow6432Node\Mozilla\Mozilla Firefox\70.0.1 (x86 en-US)\Main /v PathToExe +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
  win-detect-browsers   @ default location +2ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
  win-detect-browsers   @ default location +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
  win-detect-browsers   @ default location +0ms
  win-detect-browsers Found chrome:
  win-detect-browsers   - C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
  win-detect-browsers   @ default location +0ms
  win-detect-browsers Found firefox:
  win-detect-browsers   - C:\Program Files (x86)\Mozilla Firefox\firefox.exe
  win-detect-browsers   @ default location +2ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files (x86)\Internet Explorer\iexplore.exe
  win-detect-browsers   @ default location +0ms
  win-detect-browsers Found ie:
  win-detect-browsers   - C:\Program Files\Internet Explorer\iexplore.exe
  win-detect-browsers   @ default location +1ms
CHROME 79 BETA 64-bit
├── Path:    C:\Program Files (x86)\Google\Chrome Beta\Application\chrome.exe
├── Version: 79.0.3945.36
├── GUID:    8237E44A-0054-442C-B6B6-EA0509993955
├─┬ Info
│ ├── FileVersion:      79.0.3945.36
│ ├── CompanyName:      Google LLC
│ ├── FileDescription:  Google Chrome
│ ├── InternalName:     chrome_exe
│ ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
│ ├── OriginalFilename: chrome.exe
│ ├── ProductName:      Google Chrome
│ ├── ProductVersion:   79.0.3945.36
│ ├── CompanyShortName: Google
│ ├── ProductShortName: Chrome
│ ├── LastChange:       3582db32b33893869b8c1339e8f4d9ed1816f143-refs/branch-heads/3945@{#614}
│ └── Official Build:   1
└─┬ Uninstall
  ├── path: C:\Program Files (x86)\Google\Chrome Beta\Application\79.0.3945.36\Installer\setup.exe
  └─┬ arguments
    ├── --uninstall
    ├── --chrome-beta
    ├── --system-level
    └── --verbose-logging

CHROME 80 CANARY 64-bit
├── Path:    C:\Users\User\AppData\Local\Google\Chrome SxS\Application\chrome.exe
├── Version: 80.0.3968.0
├── GUID:    4EA16AC7-FD5A-47C3-875B-DBF4A2008C20
├─┬ Info
│ ├── FileVersion:      80.0.3968.0
│ ├── CompanyName:      Google LLC
│ ├── FileDescription:  Google Chrome
│ ├── InternalName:     chrome_exe
│ ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
│ ├── OriginalFilename: chrome.exe
│ ├── ProductName:      Google Chrome
│ ├── ProductVersion:   80.0.3968.0
│ ├── CompanyShortName: Google
│ ├── ProductShortName: Chrome
│ ├── LastChange:       942a57022a321872a10830a40120904d79bd0536-refs/branch-heads/3968@{#1}
│ └── Official Build:   1
└─┬ Uninstall
  ├── path: C:\Users\User\AppData\Local\Google\Chrome SxS\Application\80.0.3968.0\Installer\setup.exe
  └─┬ arguments
    ├── --uninstall
    └── --chrome-sxs

CHROME 78 STABLE 64-bit
├── Path:    C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
├── Version: 78.0.3904.97
├── GUID:    8A69D345-D564-463C-AFF1-A69D9E530F96
├─┬ Info
│ ├── FileVersion:      78.0.3904.97
│ ├── CompanyName:      Google LLC
│ ├── FileDescription:  Google Chrome
│ ├── InternalName:     chrome_exe
│ ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
│ ├── OriginalFilename: chrome.exe
│ ├── ProductName:      Google Chrome
│ ├── ProductVersion:   78.0.3904.97
│ ├── CompanyShortName: Google
│ ├── ProductShortName: Chrome
│ ├── LastChange:       021b9028c246d820be17a10e5b393ee90f41375e-refs/branch-heads/3904@{#859}
│ └── Official Build:   1
└─┬ Uninstall
  ├── path: C:\Program Files (x86)\Google\Chrome\Application\78.0.3904.97\Installer\setup.exe
  └─┬ arguments
    ├── --uninstall
    ├── --system-level
    └── --verbose-logging

CHROME 80 DEV 64-bit
├── Path:    C:\Program Files (x86)\Google\Chrome Dev\Application\chrome.exe
├── Version: 80.0.3964.0
├── GUID:    401C381F-E0DE-4B85-8BD8-3F3F14FBDA57
├─┬ Uninstall
│ ├── path: C:\Program Files (x86)\Google\Chrome Dev\Application\80.0.3964.0\Installer\setup.exe
│ └─┬ arguments
│   ├── --uninstall
│   ├── --chrome-dev
│   ├── --system-level
│   └── --verbose-logging
└─┬ Info
  ├── FileVersion:      80.0.3964.0
  ├── CompanyName:      Google LLC
  ├── FileDescription:  Google Chrome
  ├── InternalName:     chrome_exe
  ├── LegalCopyright:   Copyright 2019 Google LLC. All rights reserved.
  ├── OriginalFilename: chrome.exe
  ├── ProductName:      Google Chrome
  ├── ProductVersion:   80.0.3964.0
  ├── CompanyShortName: Google
  ├── ProductShortName: Chrome
  ├── LastChange:       75f9d4c9f31c6fa9302434e99ced85dc5d8e2069-refs/branch-heads/3964@{#1}
  └── Official Build:   1

FIREFOX 70 RELEASE 32-bit
├── Path:    C:\Program Files (x86)\Mozilla Firefox\firefox.exe
├── Version: 70.0.1
└─┬ Info
  ├── FileVersion:      70.0.1
  ├── LegalCopyright:   ©Firefox and Mozilla Developers; available under the MPL 2 license.
  ├── CompanyName:      Mozilla Corporation
  ├── FileDescription:  Firefox
  ├── ProductVersion:   70.0.1
  ├── InternalName:     Firefox
  ├── LegalTrademarks:  Firefox is a Trademark of The Mozilla Foundation.
  ├── OriginalFilename: firefox.exe
  ├── ProductName:      Firefox
  └── BuildID:          20191030021342

IE 11 64-bit
├── Path:    C:\Program Files\Internet Explorer\iexplore.exe
├── Version: 11.00.18362.1
└─┬ Info
  ├── FileVersion:      11.00.18362.1
  ├── CompanyName:      Microsoft Corporation
  ├── FileDescription:  Internet Explorer
  ├── InternalName:     iexplore
  ├── LegalCopyright:   © Microsoft Corporation. All rights reserved.
  ├── OriginalFilename: IEXPLORE.EXE
  ├── ProductName:      Internet Explorer
  └── ProductVersion:   11.00.18362.1

IE 11 32-bit
├── Path:    C:\Program Files (x86)\Internet Explorer\iexplore.exe
├── Version: 11.00.18362.1
└─┬ Info
  ├── FileVersion:      11.00.18362.1
  ├── CompanyName:      Microsoft Corporation
  ├── FileDescription:  Internet Explorer
  ├── InternalName:     iexplore
  ├── LegalCopyright:   © Microsoft Corporation. All rights reserved.
  ├── OriginalFilename: IEXPLORE.EXE
  ├── ProductName:      Internet Explorer
  └── ProductVersion:   11.00.18362.1

Found 7 browsers in 25 ways within 116ms.
```

That said, while this is an improvement, I haven't reproduce the reported issues, so I can't confirm that the ChromeHTML key is the main culprit.

I did manage to hit issues on this test environment due to the default 'stable' assumption from `find-update-clients` though. That's definitely incorrect for a few cases here. My installed dev & beta versions for example have exactly the same `ap` value, but different channels. Notably my stable install does explicitly say stable here (`x64-stable-statsdef_1`), so I've changed this to an explicit check.

I'm a bit suspicious of the [bitness check](https://github.com/vweevers/win-detect-browsers/blob/master/lib/chrome/find-update-clients.js#L48) in `find-update-clients` too, since it defaults to 32, which would cause [this reported issue](https://github.com/httptoolkit/feedback/issues/46#issuecomment-544325458). I can't reproduce a similar error myself here, but how would you feel about something like `ap.has('x64') ? 64 : null` instead? I'm assuming there's no explicit 32 bit value we can check for.