### PR TITLE
Avoid throwing errors if the registry is not readable

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -41,7 +41,7 @@ exports.value = function (hive, key, valueName, callback) {
 
   key = Array.isArray(key) ? key.join('\\') : key
 
-  const result = registry.enumerateValues(hive, key)
+  const result = registry.enumerateValuesSafe(hive, key)
   const expectedName = valueName || ''
   const fqk = [shortHive || hive, key].join('\\')
 
@@ -63,7 +63,7 @@ exports.values = function (hive, key, callback) {
     hive = SHORT_HIVES.get(hive)
   }
 
-  const result = registry.enumerateValues(hive, key)
+  const result = registry.enumerateValuesSafe(hive, key)
   const obj = {}
 
   for (const item of result) {


### PR DESCRIPTION
Previously this could happen if the user did not have access to the given key (#64), and probably in other rare cases.

I can't reproduce these real registry errors myself, but I've tested this by inserting a `throw new Error()` into `enumerateValues` in registry-js.

Given that error, without this change `node cli.js --debug` crashes. With this change, it happily reports all non-registry info.