### PR TITLE
Stop detecting the Chrome-only guid & uninstall properties

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -66,7 +66,7 @@ detect(argv._, argv, function (err, browsers, methods) {
       }
 
       const label = chalk.white(labels.join(' '))
-      const atomic = ['path', 'version', 'guid'].filter(key => b[key] != null)
+      const atomic = ['path', 'version'].filter(key => b[key] != null)
       const nonAtomic = Object.keys(b).filter(key => isObject(b[key]))
 
       const pad = atomic.reduce(function (max, key) {
@@ -76,7 +76,7 @@ detect(argv._, argv, function (err, browsers, methods) {
       const nodes = atomic.map(key => {
         const value = b[key]
 
-        key = key === 'guid' ? 'GUID' : pascal(key)
+        key = pascal(key)
         key = key + ':' + pad.slice(key.length - pad.length - 1)
 
         return chalk.cyan(key) + value

--- a/lib/chrome/find-update-clients.js
+++ b/lib/chrome/find-update-clients.js
@@ -47,8 +47,7 @@ function queryState (self, hive, guid, inWoW, done) {
       const ap = new Set(client.ap.split('-'))
 
       const metadata = {
-        channel: getReleaseChannel(ap),
-        guid
+        channel: getReleaseChannel(ap)
       }
 
       // Not always available
@@ -56,27 +55,18 @@ function queryState (self, hive, guid, inWoW, done) {
         path = extractPath(client.LastInstallerSuccessLaunchCmdLine)
       }
 
-      if (client.UninstallString) {
-        const args = client.UninstallArguments
+      if (client.UninstallString && !path) {
+        // Possibly Google\Chrome\Application\<version>\Installer\setup.exe
+        // with chrome.exe at Google\Chrome\Application\chrome.exe
+        const installer = extractPath(client.UninstallString)
 
-        metadata.uninstall = {
-          path: client.UninstallString,
-          arguments: args ? args.split(' ').filter(Boolean) : []
-        }
+        if (installer && basename(dirname(installer)) === 'Installer' && basename(installer) === 'setup.exe') {
+          const path = resolve(installer, '..', '..', '..', 'chrome.exe')
 
-        if (!path) {
-          // Possibly Google\Chrome\Application\<version>\Installer\setup.exe
-          // with chrome.exe at Google\Chrome\Application\chrome.exe
-          const installer = extractPath(client.UninstallString)
-
-          if (installer && basename(dirname(installer)) === 'Installer' && basename(installer) === 'setup.exe') {
-            const path = resolve(installer, '..', '..', '..', 'chrome.exe')
-
-            return fs.access(path, fs.constants.F_OK, (err) => {
-              if (err) done()
-              else self.found(path, metadata, key + '\\UninstallString', done)
-            })
-          }
+          return fs.access(path, fs.constants.F_OK, (err) => {
+            if (err) done()
+            else self.found(path, metadata, key + '\\UninstallString', done)
+          })
         }
       }
 

--- a/readme.md
+++ b/readme.md
@@ -65,10 +65,6 @@ Additional properties are usually available but not guaranteed:
   - Firefox: `release`, `developer`, `nightly` or [`esr`](https://www.mozilla.org/en-US/firefox/organizations/faq/)
   - Older versions of Firefox: `aurora`, `beta` or `rc`;
   - Opera: `stable`, `beta` or `developer`.
-- `uninstall` (object): Chrome only. Uninstaller info with:
-  - `path` (string): path to installer;
-  - `arguments` (array): arguments to installer in order to uninstall.
-- `guid` (string): Chrome only.
 
 ## CLI
 
@@ -233,7 +229,6 @@ On Windows 10 with `--json`:
     "version": "68.0.3436.0",
     "channel": "canary",
     "arch": "amd64",
-    "guid": "4EA16AC7-FD5A-47C3-875B-DBF4A2008C20",
     "info": {
       "FileVersion": "68.0.3436.0",
       "CompanyName": "Google Inc.",
@@ -247,13 +242,6 @@ On Windows 10 with `--json`:
       "ProductShortName": "Chrome",
       "LastChange": "e0f81fe637f233bf12e821915b72bc8d2194c3f2-refs/branch-heads/3436@{#1}",
       "Official Build": "1"
-    },
-    "uninstall": {
-      "path": "C:\\Users\\vweevers\\AppData\\Local\\Google\\Chrome SxS\\Application\\68.0.3436.0\\Installer\\setup.exe",
-      "arguments": [
-        "--uninstall",
-        "--chrome-sxs"
-      ]
     }
   },
   {
@@ -262,7 +250,6 @@ On Windows 10 with `--json`:
     "version": "66.0.3359.181",
     "channel": "stable",
     "arch": "amd64",
-    "guid": "8A69D345-D564-463C-AFF1-A69D9E530F96",
     "info": {
       "FileVersion": "66.0.3359.181",
       "CompanyName": "Google Inc.",
@@ -276,14 +263,6 @@ On Windows 10 with `--json`:
       "ProductShortName": "Chrome",
       "LastChange": "a10b9cedb40738cb152f8148ddab4891df876959-refs/branch-heads/3359@{#828}",
       "Official Build": "1"
-    },
-    "uninstall": {
-      "path": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\66.0.3359.181\\Installer\\setup.exe",
-      "arguments": [
-        "--uninstall",
-        "--system-level",
-        "--verbose-logging"
-      ]
     }
   },
   {


### PR DESCRIPTION
As discussed in https://github.com/vweevers/win-detect-browsers/issues/67#issuecomment-568163288. This fixes #67.

I've still only seen 1 user hit this, so it's a very rare issue, but it would be nice to fix anyway if we can. 

I think this is technically not a major bump because `guid` and `uninstall` are both listed in the "Additional properties are usually available but not guaranteed" section from the docs. Might be worth considering a major bump anyway, if you think many people have been treating them as always present for Chrome despite that, hard for me to say.