### PR TITLE
feat: add support for detecting Opera GXStable and Opera CryptoStable

### DIFF
--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -162,6 +162,42 @@ exports.opera = {
   }
 }
 
+exports["opera-gx"] = {
+  bin: 'Launcher.exe',
+
+  find: function () {
+
+    this.programFiles('Opera GX')
+    this.registry('Clients\\StartMenuInternet\\Opera GXStable\\shell\\open\\command')
+    this.registry('Classes\\Opera GXStable\\shell\\open\\command')
+
+    this.inPath()
+  },
+
+  post: function (b) {
+    b.channel = 'stable'
+    return b
+  }
+}
+
+exports["opera-crypto"] = {
+  bin: 'Launcher.exe',
+
+  find: function () {
+
+    this.programFiles('Opera Crypto')
+    this.registry('Clients\\StartMenuInternet\\Opera CryptoStable\\shell\\open\\command')
+    this.registry('Classes\\Opera CryptoStable\\shell\\open\\command')
+    
+    this.inPath()
+  },
+
+  post: function (b) {
+    b.channel = 'stable'
+    return b
+  }
+}
+
 // Incomplete (Safari for Windows is dead anyway)
 exports.safari = {
   find: function () {


### PR DESCRIPTION
This PR enables the detection of **Opera GX** and **Opera Crypto**

Channels for these two browsers are hard coded as `stable`, because 
1. The names in the registries are prefixed with **Stable** _but_,
2. there are no official releases for other channels