### PR TITLE
Don't detect Opera in PATH to avoid false positives

### DIFF
--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -146,8 +146,6 @@ exports.opera = {
     this.programFiles('Opera developer')
     this.registry('Clients\\StartMenuInternet\\OperaDeveloper\\shell\\open\\command')
     this.registry('Classes\\OperaDeveloper\\shell\\open\\command')
-
-    this.inPath()
   },
 
   post: function (b) {


### PR DESCRIPTION
The Opera binary is just called Launcher.exe, which is very common as an exe name, so can match plenty of other programs (as one example: Intellij). Checking for this in PATH makes false positives like that extremely likely, while the other search sources are far more likely to be accurate.