### PR TITLE
Breaking: switch to ESM

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
-'use strict'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import debug from 'debug'
+import detect from './index.js'
+import browsers from './lib/browsers.js'
 
-const names = Object.keys(require('./lib/browsers'))
-
-const argv = require('yargs')
+const names = Object.keys(browsers)
+const argv = yargs(hideBin(process.argv))
   .usage([
     'win-detect-browsers [options] [name, name..]\n',
     'Write browsers to stdout as a JSON array.\n',
@@ -24,10 +27,8 @@ const argv = require('yargs')
   .argv
 
 if (argv.debug) {
-  require('debug').enable('win-detect-browsers')
+  debug.enable('win-detect-browsers')
 }
-
-const detect = require('.')
 
 async function main () {
   const start = Date.now()

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
-'use strict'
+import after from 'after'
+import Finder from './lib/finder.js'
+import defaultBrowsers from './lib/browsers.js'
 
-const after = require('after')
-const Finder = require('./lib/finder')
-const defaultBrowsers = require('./lib/browsers')
-
-module.exports = function detect (names = null, options = null) {
+export default function detect (names = null, options = null) {
   if (typeof names === 'string') {
     names = [names]
   }

--- a/lib/browsers.js
+++ b/lib/browsers.js
@@ -1,8 +1,11 @@
-'use strict'
+import ffChannel from './firefox-release-channel.js'
+import findUpdateClients from './chrome/find-update-clients.js'
+import findProgIds from './chrome/find-progids.js'
 
-const ffChannel = require('./firefox-release-channel')
+const browsers = {}
+export default browsers
 
-exports.chrome = {
+browsers.chrome = {
   find: function () {
     // Joined with filename (or [browser name].exe)
     this.dir('LOCALAPPDATA', 'Google\\Chrome\\Application')
@@ -37,11 +40,11 @@ exports.chrome = {
     this.findProgIds()
   },
 
-  findUpdateClients: require('./chrome/find-update-clients'),
-  findProgIds: require('./chrome/find-progids')
+  findUpdateClients,
+  findProgIds
 }
 
-exports.chromium = {
+browsers.chromium = {
   bin: 'chrome.exe',
 
   // Can't search for chromium in PATH, because the binary name conflicts with chrome
@@ -52,7 +55,7 @@ exports.chromium = {
   }
 }
 
-exports.firefox = {
+browsers.firefox = {
   find: function () {
     this.programFiles('Mozilla Firefox')
     this.programFiles('Firefox Developer Edition')
@@ -85,14 +88,14 @@ exports.firefox = {
   }
 }
 
-exports.beaker = {
+browsers.beaker = {
   bin: 'Beaker Browser.exe',
   find: function () {
     this.dir('LOCALAPPDATA', 'Programs\\beaker-browser')
   }
 }
 
-exports.brave = {
+browsers.brave = {
   bin: 'brave.exe',
   find: function () {
     this.programFiles('BraveSoftware\\Brave-Browser\\Application')
@@ -100,7 +103,7 @@ exports.brave = {
   }
 }
 
-exports.ie = {
+browsers.ie = {
   bin: 'iexplore.exe',
 
   find: function () {
@@ -110,7 +113,7 @@ exports.ie = {
   }
 }
 
-exports.msedge = {
+browsers.msedge = {
   bin: 'msedge.exe',
 
   find: function () {
@@ -138,7 +141,7 @@ exports.msedge = {
   }
 }
 
-exports.maxthon = {
+browsers.maxthon = {
   bin: 'Maxthon.exe',
 
   find: function () {
@@ -149,7 +152,7 @@ exports.maxthon = {
   }
 }
 
-exports.opera = {
+browsers.opera = {
   bin: 'Launcher.exe',
 
   find: function () {
@@ -178,7 +181,7 @@ exports.opera = {
   }
 }
 
-exports['opera-gx'] = {
+browsers['opera-gx'] = {
   bin: 'Launcher.exe',
 
   find: function () {
@@ -193,7 +196,7 @@ exports['opera-gx'] = {
   }
 }
 
-exports['opera-crypto'] = {
+browsers['opera-crypto'] = {
   bin: 'Launcher.exe',
 
   find: function () {
@@ -209,7 +212,7 @@ exports['opera-crypto'] = {
 }
 
 // Incomplete (Safari for Windows is dead anyway)
-exports.safari = {
+browsers.safari = {
   find: function () {
     this.startMenu()
     this.registry('Apple Computer, Inc.\\Safari', 'BrowserExe')
@@ -217,7 +220,7 @@ exports.safari = {
   }
 }
 
-exports.yandex = {
+browsers.yandex = {
   bin: 'browser.exe',
 
   find: function () {

--- a/lib/chrome/find-progids.js
+++ b/lib/chrome/find-progids.js
@@ -1,10 +1,8 @@
-'use strict'
+import after from 'after'
+import extractPath from '../extract-path.js'
+import registry from '../registry.js'
 
-const extractPath = require('../extract-path')
-const after = require('after')
-const registry = require('../registry')
-
-module.exports = function findProgIds () {
+export default function findProgIds () {
   // We could read HKCR, which is composed of HKLM\Software\Classes and
   // HKCU\Software\Classes, but that hive is only refreshed on restart.
   const next = this.plan(2)

--- a/lib/chrome/find-update-clients.js
+++ b/lib/chrome/find-update-clients.js
@@ -1,10 +1,8 @@
-'use strict'
-
-const extractPath = require('../extract-path')
-const env = require('windows-env')
-const fs = require('fs')
-const { basename, resolve, dirname } = require('path')
-const registry = require('../registry')
+import env from 'windows-env'
+import fs from 'node:fs'
+import { basename, resolve, dirname } from 'node:path'
+import extractPath from '../extract-path.js'
+import registry from '../registry.js'
 
 const GUIDS = [
   '401C381F-E0DE-4B85-8BD8-3F3F14FBDA57', // dev
@@ -21,7 +19,7 @@ const CHANNELS = [
   'dev'
 ]
 
-module.exports = function findUpdateClients () {
+export default function findUpdateClients () {
   const next = this.plan(GUIDS.length * (env.X64 ? 4 : 2))
 
   GUIDS.forEach(guid => {

--- a/lib/extract-path.js
+++ b/lib/extract-path.js
@@ -1,6 +1,4 @@
-'use strict'
-
-module.exports = function extractPath (str) {
+export default function extractPath (str) {
   const m = /([a-z]:\\[^:\t"]+)/i.exec(str)
   return (m && m[1] && m[1].trim()) || null
 }

--- a/lib/finder.js
+++ b/lib/finder.js
@@ -1,21 +1,19 @@
-'use strict'
+import dbg from 'debug'
+import which from 'which'
+import env from 'windows-env'
+import mt from 'pe-machine-type'
+import util from 'node:util'
+import path from 'node:path'
+import existent from 'existent'
+import registry from './registry.js'
+import versionInfo from './version-info.js'
+import extractPath from './extract-path.js'
 
-const debug = require('debug')('win-detect-browsers')
-const which = require('which')
-const env = require('windows-env')
-const mt = require('pe-machine-type')
-const util = require('util')
-const path = require('path')
-const existent = require('existent')
-const registry = require('./registry')
-
-const versionInfo = require('./version-info')
-const extractPath = require('./extract-path')
 const HIVES = ['HKLM', 'HKCU']
 const kCallback = Symbol('callback')
+const debug = dbg('win-detect-browsers')
 
-module.exports = Finder
-
+// TODO: rewrite to class
 function Finder (name, props) {
   for (const k in props) this[k] = props[k]
 
@@ -267,6 +265,8 @@ Finder.prototype.end = function () {
   this.closed = true
   this[kCallback](this.results, this.methods)
 }
+
+export default Finder
 
 function debugKey (key, valueName) {
   return valueName ? key + ' /v ' + valueName : key

--- a/lib/firefox-release-channel.js
+++ b/lib/firefox-release-channel.js
@@ -1,8 +1,6 @@
-'use strict'
-
 const VERSION_RE = /([\d.]+)(([ab]| RC)(\d+)|esr)?/
 
-module.exports = function releaseChannel (version) {
+export default function releaseChannel (version) {
   const match = version.match(VERSION_RE)
 
   if (match !== null) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,24 +1,8 @@
-'use strict'
-
-const debug = require('debug')('win-detect-browsers')
-const registry = process.platform === 'win32' ? require('registry-js') : tryRequire()
-
-function tryRequire () {
-  try {
-    return require('registry-js')
-  } catch (err) {
-    debug(err)
-
-    return {
-      enumerateValues: function dummy () {
-        return []
-      }
-    }
-  }
-}
+// Note: registry-js internally has a `process.platform === 'win32'` check so it
+// won't load its native addon on other platforms (good)
+import registry from 'registry-js'
 
 const HKEY = registry.HKEY
-
 const SHORT_HIVES = new Map([
   ['HKLM', HKEY.HKEY_LOCAL_MACHINE],
   ['HKCU', HKEY.HKEY_CURRENT_USER],
@@ -27,7 +11,10 @@ const SHORT_HIVES = new Map([
   ['HKU', HKEY.HKEY_USERS]
 ])
 
-exports.value = function (hive, key, valueName, callback) {
+// TODO: refactor
+const api = {}
+
+api.value = function (hive, key, valueName, callback) {
   if (typeof valueName === 'function') {
     // Get default value
     callback = valueName
@@ -60,7 +47,7 @@ exports.value = function (hive, key, valueName, callback) {
   process.nextTick(callback, err)
 }
 
-exports.values = function (hive, key, callback) {
+api.values = function (hive, key, callback) {
   if (SHORT_HIVES.has(hive)) {
     hive = SHORT_HIVES.get(hive)
   }
@@ -74,3 +61,5 @@ exports.values = function (hive, key, callback) {
 
   process.nextTick(callback, null, obj)
 }
+
+export default api

--- a/lib/version-info.js
+++ b/lib/version-info.js
@@ -1,21 +1,13 @@
 'use strict'
 
-const debug = require('debug')('win-detect-browsers')
-const vi = process.platform === 'win32' ? require('win-version-info') : tryRequire()
+// Note: win-version-info internally has a `process.platform === 'win32'` check
+// so it won't load its native addon on other platforms (good)
+import vi from 'win-version-info'
+import dbg from 'debug'
 
-function tryRequire () {
-  try {
-    return require('win-version-info')
-  } catch (err) {
-    debug(err)
+const debug = dbg('win-detect-browsers')
 
-    return function noop () {
-      return {}
-    }
-  }
-}
-
-module.exports = function annotate (b) {
+export default function annotate (b) {
   let info
 
   try {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Fast and native browser detection on Windows",
   "author": "Vincent Weevers",
   "license": "MIT",
+  "type": "module",
   "main": "index.js",
   "bin": "cli.js",
   "files": [

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 _If you are upgrading: please see the [changelog](CHANGELOG.md)._
 
 ```js
-const detect = require('win-detect-browsers')
+import detect from 'win-detect-browsers'
 
 // All browsers
 const browsers = await detect()

--- a/test.js
+++ b/test.js
@@ -1,5 +1,3 @@
-'use strict'
-
 // Requirements to run tests:
 //
 // - Chrome
@@ -12,18 +10,21 @@
 // --opera: requires Opera Stable, Beta and Developer
 // --canary: requires Chrome Canary
 
+import test from 'tape'
+import gen from 'win-dummy-exe'
+import yargs from 'yargs'
+import env from 'windows-env'
+import path from 'node:path'
+import detect from './index.js'
+import defaultBrowsers from './lib/browsers.js'
+import ffChannel from './lib/firefox-release-channel.js'
+import registry from './lib/registry.js'
+import { hideBin } from 'yargs/helpers'
+
+// TODO: why did we need this? Test without.
 process.stderr.setMaxListeners(100)
 
-const test = require('tape')
-const detect = require('./')
-const path = require('path')
-const gen = require('win-dummy-exe')
-const env = require('windows-env')
-const defaultBrowsers = require('./lib/browsers')
-const ffChannel = require('./lib/firefox-release-channel')
-const registry = require('./lib/registry')
-
-const argv = require('yargs')
+const argv = yargs(hideBin(process.argv))
   .boolean('opera')
   .boolean('canary')
   .argv
@@ -152,7 +153,7 @@ test('ignores non-exe', async function (t) {
     test: {
       bin: 'test.js',
       find: function () {
-        this.dir(__dirname)
+        this.dir(process.cwd())
       }
     }
   }


### PR DESCRIPTION
If you previously did:

```js
const detect = require('win-detect-browsers')
```

You must now do:

```js
import detect from 'win-detect-browsers'
```