### PR TITLE
Fix registry.js import

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,6 +1,6 @@
 // Note: registry-js internally has a `process.platform === 'win32'` check so it
 // won't load its native addon on other platforms (good)
-import registry from 'registry-js'
+import * as registry from 'registry-js'
 
 const HKEY = registry.HKEY
 const SHORT_HIVES = new Map([


### PR DESCRIPTION
Registry.js doesn't actually have a default import.

Its output is CJS ([this](https://app.unpkg.com/registry-js@1.16.1/files/dist/lib/registry.js) is effectively what's being imported) and exports an explicit list of fields with no `default` set.

Node.js will emulate a fake default export in this case to make this work regardless, but some other environments (most notably ts-node & tsx) won't do that, which makes this fail. To repro:

Clone this repo, `npm install tsx`, then:

```bash
> node --import tsx -e "require('.')"
.../win-detect-browsers/lib/registry.js:5
const HKEY = registry.HKEY
                      ^

TypeError: Cannot read properties of undefined (reading 'HKEY')
```

Really this _should_ fail - the equivalent ESM code for this module would really be a set of named exports, with no default export. This PR fixes that so this can be used with tsx/ts-node, and makes the import conceptually more correct by pulling the module namespace that's actually being exported.